### PR TITLE
Rework the code to use Xbyak::CodeGenerator and DKUtil's IniConfig

### DIFF
--- a/Plugin/cmake/Plugin.h.in
+++ b/Plugin/cmake/Plugin.h.in
@@ -5,6 +5,7 @@ namespace Plugin
 {
 	inline constexpr auto NAME = "@PROJECT_NAME@"sv;
 	inline constexpr auto AUTHOR = "MrTeferi"sv;
+	inline constexpr auto SETTINGS_NAME = "@PROJECT_NAME@.ini"sv;
 	inline constexpr auto Version = 
 		@PROJECT_VERSION_MAJOR@u * 10000 +
 		@PROJECT_VERSION_MINOR@u * 100 +

--- a/Plugin/src/PCH.h
+++ b/Plugin/src/PCH.h
@@ -124,3 +124,6 @@ using namespace REL::literals;
 
 using namespace DKUtil::Alias;
 using namespace DKUtil::Hook;
+
+// Settings
+#include "Settings.hpp"

--- a/Plugin/src/Settings.hpp
+++ b/Plugin/src/Settings.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "DKUtil/Config.hpp"
+
+using namespace DKUtil::Alias;
+
+class Settings : public dku::model::Singleton<Settings>
+{
+private:
+    IniConfig mainConfig = COMPILE_PROXY(Plugin::SETTINGS_NAME);
+
+    Integer shipNameMaxChars{ "ShipNameMaxChars", "Main"};
+public:
+    uint8_t GetShipNameMaxChars()
+    {
+        return static_cast<uint8_t>(*shipNameMaxChars);
+    }
+
+    void Load() noexcept
+    {
+        static std::once_flag bound;
+        std::call_once(bound, [&]() { mainConfig.Bind<10, 255>(shipNameMaxChars, 25); });
+
+        mainConfig.Load();
+    }
+};

--- a/Plugin/src/Settings.hpp
+++ b/Plugin/src/Settings.hpp
@@ -11,15 +11,15 @@ private:
 
     Integer shipNameMaxChars{ "ShipNameMaxChars", "Main"};
 public:
-    uint8_t GetShipNameMaxChars()
+    int GetShipNameMaxChars()
     {
-        return static_cast<uint8_t>(*shipNameMaxChars);
+        return *shipNameMaxChars;
     }
 
     void Load() noexcept
     {
         static std::once_flag bound;
-        std::call_once(bound, [&]() { mainConfig.Bind<10, 255>(shipNameMaxChars, 25); });
+        std::call_once(bound, [&]() { mainConfig.Bind<10, 1000>(shipNameMaxChars, 25); });
 
         mainConfig.Load();
     }

--- a/Plugin/src/Settings.hpp
+++ b/Plugin/src/Settings.hpp
@@ -19,7 +19,7 @@ public:
     void Load() noexcept
     {
         static std::once_flag bound;
-        std::call_once(bound, [&]() { mainConfig.Bind<10, 1000>(shipNameMaxChars, 25); });
+        std::call_once(bound, [&]() { mainConfig.Bind<10, 255>(shipNameMaxChars, 25); });
 
         mainConfig.Load();
     }

--- a/Plugin/src/main.cpp
+++ b/Plugin/src/main.cpp
@@ -28,8 +28,7 @@ namespace ShipCharCount
         Prolog()
         {
             // save rax to the stack
-            sub(rsp, 0x10);
-            mov(ptr[rsp], rax);
+            push(rax);
         }
     };
 
@@ -41,8 +40,7 @@ namespace ShipCharCount
             mov(r8d, al);
 
             // restore rax from stack
-            mov (rax, ptr[rsp]);
-            add(rsp, 0x10);
+            pop(rax);
         }
     };
 

--- a/Plugin/src/main.cpp
+++ b/Plugin/src/main.cpp
@@ -37,14 +37,14 @@ namespace ShipCharCount
         Epilog()
         {
             // write the return value from the hook function to r8d
-            mov(r8d, al);
+            mov(r8d, eax);
 
             // restore rax from stack
             pop(rax);
         }
     };
 
-    uint8_t Hook_GetMaxCharCount()
+    int Hook_GetMaxCharCount()
     {
         return Settings::GetSingleton()->GetShipNameMaxChars();
     }

--- a/Plugin/src/main.cpp
+++ b/Plugin/src/main.cpp
@@ -27,6 +27,8 @@ namespace ShipCharCount
     {
         Prolog()
         {
+            // save rcx to the stack
+            push(rcx);
             // save rax to the stack
             push(rax);
         }
@@ -41,6 +43,8 @@ namespace ShipCharCount
 
             // restore rax from stack
             pop(rax);
+            // restore rcx from stack
+            pop(rcx);
         }
     };
 


### PR DESCRIPTION
I used what @gottyduke thought me to make use of the DKUtil.  
Replaced your self made Ini code with DKUtil IniConfig. it works exactly the same as before.  
Also I used Xbyak::CodeGenerator to write the assembly code in combination with a function call to get the value from settings

The assembly code works now different as before.  
Instead of writing to [rcx+0C8] directly, it overwrites "r8d" and uses the original code **mov [rcx+0C8], r8d** to assign it to "rcx+0C8h".  
Together with pattern search, the code is not dependent on offsets. If **mov [rcx+0C8], r8d** changes for example to **mov [rcx+0C4], r8d**, it will still work, because we use the original code and just write to r8d before the original code gets executed.